### PR TITLE
[pw-azure-bug-fix] Add redirect for https://mrms.ncep.noaa.gov in doc/conf.py

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -125,6 +125,8 @@ linkcheck_allowed_redirects = {r"https://github\.com/ufs-community/ufs-srweather
                                  r"https://sso\.noaa\.gov\:443/openam/SSORedirect/metaAlias/noaa\-online/idp\?SAMLRequest\=.*",
                                r"https://github\.com/ufs-community/ufs\-srweather\-app/issues/.*": 
                                  r"https://github\.com/login\?return\_to\=https.*",
+                               r"https://mrms\.ncep\.noaa\.gov/data/": 
+                                 r"https://mrms\.ncep\.noaa\.gov",
                                }
 
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
The documentation will fail to build due to a redirect from https://mrms.ncep.noaa.gov/data/ to https://mrms.ncep.noaa.gov.  This update adds the necessary redirect to doc/conf.py to allow the documentation to build.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## TESTS CONDUCTED: 
The [documentation](https://github.com/MichaelLueken/ufs-srweather-app/actions/runs/12280910312/job/34268483536) will properly build without warnings and errors

